### PR TITLE
fix: removing duplicates from the transport details

### DIFF
--- a/models/dashboards/transport/pbi_tables/transport_report_aggregated.sql
+++ b/models/dashboards/transport/pbi_tables/transport_report_aggregated.sql
@@ -49,7 +49,7 @@ with
         {# Added the sectours abbriviation depends of parcours numbers  #}
         select e.annee, e.fiche, e.bloc_1, e.bloc_2, e.ele_am, e.ele_pm, d.abbr_sector
         from ele as e
-        left join
+        inner join
             {{ ref("transport_report_details") }} as d on e.id_parc = d.id_parc_inter
         group by e.annee, e.fiche, e.bloc_1, e.bloc_2, e.ele_am, e.ele_pm, d.abbr_sector
     ),


### PR DESCRIPTION
# Objectives of the Pull Request ? 
* The PR adds a hack tempfix support for an edge case where the same cricui_id / parcours_id is used accross multiples period. Since that'schouldn't be the case we just removed thoose case from the details table the report is built upon. This will be refactored when the dashboard will be rebuilt from scratch 