### PR TITLE
fix: Exclusion des données NE dans res_epreuves

### DIFF
--- a/models/dashboards/educ_serv/res_epreuves/pbi_tables/rstep_report_epreuves_obligatoires_internes.sql
+++ b/models/dashboards/educ_serv/res_epreuves/pbi_tables/rstep_report_epreuves_obligatoires_internes.sql
@@ -47,8 +47,8 @@ with
             {{ ref("fact_yearly_student") }} as el_y
             on res.fiche = el_y.fiche
             and res.annee = el_y.annee
-
         left join {{ ref("dim_eleve") }} as el on res.fiche = el.fiche and genre != 'x'
+        where res.res_comp_etape != 'NE'  -- Enlève les NE sur res_comp_etape
     ),
     agg as (
         select


### PR DESCRIPTION
tldr:

le bogue est que dans la table rstep_report_epreuves_obligatoires_internes il y a des resultats null ce qui fausse le calcul du nbr d'élèves (count (fiche)) en comparaison avec avec le nbr d'élève en maitrise, en difficulté et en échec (sum(is_echec))